### PR TITLE
update readme for a post-open-source world

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 ![tldraw](https://user-images.githubusercontent.com/15892272/210352645-7ca6be99-a7d3-481d-810e-dec00b67638b.png)
 
-This repo is a place to submit issues & bugs for tldraw's [beta version](https://beta.tldraw.com).
+This repo **_used to_** be a place to submit issues & bugs for the new tldraw...
 
-> **[Click here to submit a new issue](https://github.com/tldraw/tldraw-beta/issues/new)**
+But we've open-sourced now! 🎉
 
-
-<br>
-<br>
-
-*Looking for the original open source project for tldraw.com? [Click here](https://github.com/tldraw).*
+So if you want to submit an issue, please head to the [main repo](https://github.com/tldraw/tldraw).


### PR DESCRIPTION
**Don't merge until we've open-sourced the new tldraw.**

This PR updates the README of this repo to reflect the open-sourcing of the new tldraw.